### PR TITLE
docs: update Kimi K3 model card from official release

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@
 | [Kimi K2](./models/kimi_k_2)              | MLA+MoE                            | [link](./models/kimi_k_2/README.md)       | 
 | [DeepSeek V3.2](./models/deepseek_v3_2)   | MLA+DSA                            | [link](./models/deepseek_v3_2/README.md)  | 
 | [Kimi K2.5](./models/kimi_k_2_5)          | MLA+MoE+MoonViT                    | [link](./models/kimi_k_2_5/README.md)     | 
-| [Kimi K3](./models/kimi_k_3)              | KDA+Gated MLA+AttnRes+Stable LatentMoE | [link](./models/kimi_k_3/README.md)（权重待 2026-07-27 发布） | 
+| [Kimi K3](./models/kimi_k_3)              | KDA+Gated MLA+AttnRes+Stable LatentMoE | [link](./models/kimi_k_3/README.md)       | 
 | [GLM 5](./models/glm_5)                   | MLA(DSA)+MoE                       | [link](./models/glm_5/README.md)          | 
 | [MiniMax M2.5](./models/minimax_m_2_5)    | GQA+MoE                            | [link](./models/minimax_m_2_5/README.md)  |
 | [Qwen3-VL](./models/qwen3_vl)             | Dense+MoE+DeepStack+Interleaved-MRoPE | [link](./models/qwen3_vl/README.md)        |

--- a/models/README.md
+++ b/models/README.md
@@ -9,7 +9,7 @@
 | [DeepSeek V3.2](./deepseek_v3_2) | MLA+DSA | 685B级 | 128K | 2025年12月 |
 | [DeepSeek V4](./deepseek_v4) | Hybrid Attention(CSA+HCA)+MoE+mHC | 1.6T/49B（Pro）；284B/13B（Flash） | 1M | 2026年4月 |
 | [Kimi K2.5](./kimi_k_2_5) | MLA+MoE+MoonViT | 1T/32B | 256K | 2026年1月 |
-| [Kimi K3](./kimi_k_3) | KDA+Gated MLA+AttnRes+Stable LatentMoE | 2.8T/（激活量待公布） | 1M | 2026年7月（权重计划 7/27 发布） |
+| [Kimi K3](./kimi_k_3) | KDA+Gated MLA+AttnRes+Stable LatentMoE | 2.8T/104B | 1M | 2026年7月 |
 | [GLM 5](./glm_5) | MLA(DSA)+MoE | 744B/40B | 200K | 2026年2月 |
 | [MiniMax M2.5](./minimax_m_2_5) | GQA+MoE | 229B/10B | 200K | 2026年2月 |
 | [Qwen3.5](./qwen3_5) | Gated DeltaNet+Gated Attention+MoE | 397B/17B（MoE版） | 262K | 2026年2月 |
@@ -48,7 +48,7 @@
   <img src="kimi_k_2_5/kimi_k_2_5_architecture.jpg" alt="Kimi K2.5架构图" />
 </p>
 
-- [Kimi K3模型卡片](./kimi_k_3)（开源权重与技术报告尚未发布）
+- [Kimi K3模型卡片](./kimi_k_3)
 
 <p style="text-align: center;">
   <img src="kimi_k_3/kimi_k_3_architecture.jpg" alt="Kimi K3架构图" />

--- a/models/kimi_k_3/README.md
+++ b/models/kimi_k_3/README.md
@@ -1,10 +1,8 @@
 # Kimi K3模型简介
 
-> **发布状态（重要）**：截至本文档整理时，Kimi K3 **开源权重与技术报告尚未发布**。官方计划于 **2026年7月27日** 前放出完整模型权重；架构、训练与评测的更多细节将随 **Kimi K3 Technical Report** 一并公布。当前可通过 Kimi 产品与官方 API（`kimi-k3`）使用；下列参数表中未公开项暂留空，待官方材料补齐后再更新。
+Kimi K3是Moonshot AI（Kimi）目前能力最强的开源旗舰模型，也是首个达到 **2.8T（约3T级）参数规模** 的开源模型。模型基于 **Kimi Delta Attention（KDA）** 与 **Attention Residuals（AttnRes）** 构建，采用 **Stable LatentMoE**（896 专家中激活 16 个），原生支持视觉（MoonViT-V2），上下文窗口达 **1M tokens**，面向长程编程、知识工作与推理等前沿智能场景。官方称相较 Kimi K2，整体 scaling 效率约提升 **2.5×**。
 
-Kimi K3是Moonshot AI（Kimi）目前能力最强的旗舰模型，也是首个公开宣称达到 **2.8T（约3T级）参数规模** 的开源方向模型。模型原生支持视觉（图像/视频），上下文窗口达 **1M tokens**，面向长程编程（long-horizon coding）、知识工作与推理等前沿智能场景。
-
-相较 Kimi K2，官方称在架构与训练配方共同作用下，整体 scaling 效率约提升 **2.5×**。注意力侧采用 **Kimi Delta Attention（KDA）** 与 **Attention Residuals（AttnRes）**；专家侧采用 **Stable LatentMoE**，在 **896** 个专家中有效激活 **16** 个。默认开启 thinking，并通过 `reasoning_effort`（`low` / `high` / `max`，默认 `max`）调节推理强度。
+模型始终开启 thinking，并通过 `reasoning_effort`（`low` / `high` / `max`，默认 `max`）调节推理强度；多轮对话需回传完整 `reasoning_content`（preserved thinking history）。权重与代码仓库均以 [Kimi K3 License](https://huggingface.co/moonshotai/Kimi-K3) 开源。
 
 ## 整体架构
 
@@ -12,61 +10,72 @@ Kimi K3是Moonshot AI（Kimi）目前能力最强的旗舰模型，也是首个�
   <img src="kimi_k_3_architecture.jpg" alt="Kimi K3架构图" />
 </p>
 
-> 上图来自官方博客示意图。架构图中可见 **KDA**、**Gated MLA**、**Stable LatentMoE** 以及跨层的 **AttnRes（Block n−1 / n−2 / n−3）** 等模块；细分层数配比、隐藏维度等以即将发布的技术报告为准。
-
 ## 模块说明
 
-主要参数如下（仅填入官方博客 / API 文档已明确披露的项，其余留空）：
+主要参数如下（来源：[官方模型卡片](https://huggingface.co/moonshotai/Kimi-K3) / [技术报告](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf)）：
 
-| **架构**                     | 混合专家模型（MoE）+ KDA + AttnRes |
-| ---------------------------- | ---------------------------------- |
-| **总参数量**                 | 2.8T                               |
-| **激活参数量**               |                                    |
-| **层数**（含稠密层）         |                                    |
-| **稠密层数量**               |                                    |
-| **注意力隐藏维度**           |                                    |
-| **MoE隐藏维度**（每个专家） |                                    |
-| **注意力头数**               |                                    |
-| **专家数量**                 | 896                                |
-| **每token选择的专家数**    | 16                                 |
-| **共享专家数量**             |                                    |
-| **词表大小**                 |                                    |
-| **上下文长度**               | 1M                                 |
-| **注意力机制**               | KDA + Gated MLA（混合）            |
-| **残差 / 跨层连接**          | AttnRes                            |
-| **MoE框架**                  | Stable LatentMoE                   |
-| **激活函数**                 | SiTU（Sigmoid Tanh Unit）          |
-| **视觉编码器**               | （原生多模态；具体结构待技术报告） |
-| **视觉编码器参数量**         |                                    |
-| **训练量化**                 | MXFP4 weights + MXFP8 activations（自 SFT 起 QAT） |
+| **架构**                     | 混合专家模型（MoE） |
+| ---------------------------- | ------------------- |
+| **总参数量**                 | 2.8T                |
+| **激活参数量**               | 104B                |
+| **层数**（含稠密层）         | 93                  |
+| **稠密层数量**               | 1                   |
+| **注意力层构成**             | 69 KDA + 24 Gated MLA |
+| **注意力隐藏维度**           | 7168                |
+| **Latent MoE 维度**          | 3584                |
+| **MoE隐藏维度**（每个专家） | 3072                |
+| **注意力头数**               | 96                  |
+| **专家数量**                 | 896                 |
+| **每token选择的专家数**    | 16                  |
+| **共享专家数量**             | 2                   |
+| **词表大小**                 | 160K                |
+| **上下文长度**               | 1M（1048576）       |
+| **注意力机制**               | KDA & Gated MLA     |
+| **残差 / 跨层连接**          | AttnRes             |
+| **MoE框架**                  | Stable LatentMoE    |
+| **激活函数**                 | SiTU-GLU            |
+| **视觉编码器**               | MoonViT-V2          |
+| **视觉编码器参数量**         | 401M                |
+| **量化**                     | MXFP4 weights / MXFP8 activations（自 SFT 起 QAT） |
+| **模态**                     | Text, Image         |
 
 ### 语言模块
 
-相对 Kimi K2 / K2.5（MLA + MoE），官方公开的主要演进包括：
+相对 Kimi K2 / K2.5（MLA + MoE），LLM 部分的主要差异如下：
 
-- **Kimi Delta Attention（KDA）**：混合线性注意力，用于在更长序列上高效扩展注意力计算；官方称将同步向 vLLM 贡献适配 KDA 的 prefix / prefill cache 实现。
-- **Attention Residuals（AttnRes）**：在深度方向上选择性检索历史层表示，而非均匀累加残差。
-- **Gated MLA**：与 KDA 并存于架构图中，用于提升注意力选择性（具体层间配比待技术报告）。
-- **Stable LatentMoE**：专家稀疏度进一步提高（896 选 16）；路由侧引入 **Quantile Balancing**（由 router score 分位数直接推导专家分配）。
-- **优化与激活**：训练侧提及 **Per-Head Muon**；激活侧采用 **SiTU**。
-- **部署提示**：官方建议在 **≥64** 加速器的 supernode 配置上部署，以利于大带宽通信域下的推理效率。
+- 总参数 2.8T / 激活 104B（K2.5：1T / 32B）
+- 层数 93，其中仅 1 层稠密层；注意力层按 **69 KDA + 24 Gated MLA** 混合（约 3:1）
+- 注意力头数 96（K2.5：64），隐藏维度仍为 7168
+- MoE：896 专家、每 token 选 16、共享专家 2；专家 FFN 隐层 3072，并引入 Latent MoE 维度 3584（Stable LatentMoE）
+- 激活函数改为 **SiTU-GLU**（K2.5：SwiGLU）
+- 跨层引入 **AttnRes**，在深度方向选择性聚合历史层表示
+- 路由侧配合 **Quantile Balancing**；训练侧提及 **Per-Head Muon**；自 SFT 起做 MXFP4/MXFP8 量化感知训练
 
-更完整的语言侧结构说明待技术报告与开源权重发布后补充。
+部署上官方推荐 vLLM / SGLang / TokenSpeed，并建议在较大高带宽通信域（如 ≥64 加速器的 supernode）上服务。
 
 ### 视觉模块
 
-官方称 K3 为原生多模态架构，统一理解文本、图像与视频（产品与 API 均支持视觉输入；API 侧图像需 base64 / `ms://`，不支持公网图片 URL）。
+视觉模块采用 **MoonViT-V2**（约 401M 参数），相对 K2.5 的 MoonViT（约 400M）为同系列升级。模型卡片模态写明 Text / Image；产品与评测侧亦覆盖视频理解（如 Video-MME）。
 
-视觉编码器名称、参数量、与语言模型的融合细节（如 Projector / token merge 流程）**尚未在公开材料中给出**，待技术报告补充。
+**视觉与语言融合的关键步骤**（与 Kimi VL / K2.5 路线一致，细节以技术报告与权重实现为准）：
+
+1. **预处理**：由 ImageProcessor 完成抽帧（视频）、尺寸调整、padding，再切分为 **Patch**，得到模型可用的视觉张量。
+2. **Patch嵌入**：对 patch 做卷积式嵌入并叠加位置编码（含时间与空间）。
+3. **编码**：经多层 Encoder 堆叠，提取高层视觉特征。
+4. **Patch池化与merge**：通过 `merge_kernel` 等在空间（及配置下的时间）维度聚合，压缩视觉 token 数量。
+5. **MM Projector**：将视觉 hidden 维度映射到与文本一致的 `text_hidden_size`（如 MLP / PatchMerger）。
+6. **序列拼接**：按占位符将视觉特征写入文本 embedding 序列，得到最终送入 LLM 的 `inputs_embeds` 与 `attention_mask`。
+
+视觉–语言数据处理流程可参考：[VLM视觉–语言融合流程解析（Kimi K2.5/VL）](https://zhuanlan.zhihu.com/p/2018404307385500510)
 
 ## 相关资料
 
+- [技术报告（PDF）](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf)
+- [官方仓库（MoonshotAI/Kimi-K3）](https://github.com/MoonshotAI/Kimi-K3)
+- [模型卡片与权重（Hugging Face）](https://huggingface.co/moonshotai/Kimi-K3)
+- [模型卡片与权重（ModelScope）](https://www.modelscope.cn/models/moonshotai/Kimi-K3)
 - [整体介绍（官方博客）](https://www.kimi.com/zh-cn/blog/kimi-k3)
-- [英文版官方博客](https://www.kimi.com/en/blog/kimi-k3)
-- [API 快速开始（官方文档）](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart)
-- [Kimi Delta Attention / Kimi Linear（官方仓库）](https://github.com/MoonshotAI/Kimi-Linear)
-- [Attention Residuals（官方仓库）](https://github.com/MoonshotAI/Attention-Residuals)
-- [FlashKDA 算子（官方仓库）](https://github.com/MoonshotAI/FlashKDA)
-- 模型卡片与权重（Hugging Face）：待 2026-07-27 权重发布后补充
-- 模型卡片与权重（ModelScope）：待发布后补充
-- 技术报告：待发布后补充
+- [API 快速开始](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart)
+- [Kimi Delta Attention / Kimi Linear](https://github.com/MoonshotAI/Kimi-Linear)
+- [Attention Residuals](https://github.com/MoonshotAI/Attention-Residuals)
+- [FlashKDA 算子](https://github.com/MoonshotAI/FlashKDA)


### PR DESCRIPTION
## Summary
- 按官方权重与技术报告回填 Kimi K3 完整规格（2.8T/104B、69 KDA+24 Gated MLA、MoonViT-V2 等）
- 更新 models 与仓库 README 索引，去掉待发布标注

## Test plan
- [x] 确认 README 链接与架构图可正常打开